### PR TITLE
Use git2go to support regexp in gitignore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 `hawkeye` is a cli tool to list file paths from the current directory with considering .gitignore file if exists.
 
+## Dependency
+
+`hawkeye` depends on [libgit2/git2go](https://github.com/libgit2/git2go) library to recognize gitignore file.
+
+So you should install `libgit2` before install `hawkeye`.
+
+NOTE: Now, I use `hawkeye` with `libgit2` v0.24.3 on MacOS. :smile:
+
 # HowToUse
 
 Just call `hawkeye` command like this.

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 2835d62f40a4c903b57d8456951a13d66419b1db50f743e714e3317709fd09f2
-updated: 2016-11-21T13:08:20.131671882+09:00
+updated: 2016-12-04T13:54:24.262682887+09:00
 imports:
 - name: github.com/jessevdk/go-flags
-  version: f2785f5820ec967043de79c8be97edfc464ca745
-- name: github.com/monochromegane/go-gitignore
-  version: 38717d0a108ca0e5af632cd6845ca77d45b50729
+  version: d6bd1ed4cdbe19f5fc9cc03da1bc440c62f743f1
+- name: github.com/libgit2/git2go
+  version: 1c8297ab834aa3ca5f3c4128ded2758a680a9e60
 testImports: []

--- a/ignore_filter.go
+++ b/ignore_filter.go
@@ -1,37 +1,39 @@
 package main
 
-import (
-	"os"
-	"path/filepath"
-
-	"github.com/monochromegane/go-gitignore"
-)
+import git "github.com/libgit2/git2go"
 
 // IgnoreMatcher is an interface to check whether the target is match or not.
 type IgnoreMatcher interface {
 	Match(path string, isDir bool) bool
 }
 
-// NewIgnoreMatcher return new Matcher instance.
-func NewIgnoreMatcher(opts *Options) (IgnoreMatcher, error) {
-	return getIgnoreMatcher(opts.Path)
+type Matcher struct {
+	repo *git.Repository
 }
 
-func getIgnoreMatcher(path string) (gitignore.IgnoreMatcher, error) {
-	gitIgnoreFile, err := filepath.Rel(path, ".gitignore")
+// NewIgnoreMatcher return new Matcher instance.
+func NewIgnoreMatcher(opts *Options) (IgnoreMatcher, error) {
+	repo, err := git.OpenRepository(opts.Path)
 	if err != nil {
 		showError("%v\n", err)
 		return nil, err
 	}
 
-	if _, err := os.Stat(gitIgnoreFile); err != nil {
-		return nil, nil
+	return &Matcher{
+		repo,
+	}, nil
+}
+
+func (matcher *Matcher) Match(path string, isDir bool) bool {
+	if matcher.repo == nil {
+		return false
 	}
 
-	matcher, err := gitignore.NewGitIgnore(gitIgnoreFile)
+	ignored, err := matcher.repo.IsPathIgnored(path)
 	if err != nil {
 		showError("%v\n", err)
-		return nil, err
+		return false
 	}
-	return matcher, nil
+
+	return ignored
 }

--- a/walker.go
+++ b/walker.go
@@ -61,16 +61,29 @@ func (walker *Walker) targetHandler(path string, info os.FileInfo, e error) erro
 		return err
 	}
 
-	if walker.isIgnoreTarget(rel, info) {
-		if info.IsDir() {
-			return filepath.SkipDir
-		}
-	}
-
 	if rel == "." {
 		return nil
 	}
 
-	showMsg("%s\n", rel)
+	if walker.isIgnoreTarget(rel, info) {
+		if info.IsDir() {
+			return filepath.SkipDir
+		} else {
+			return nil
+		}
+	}
+
+	showMsg("%s\n", formatPath(rel, info))
 	return nil
+}
+
+func formatPath(rel string, info os.FileInfo) string {
+	const sep = string(os.PathSeparator)
+
+	result := "." + sep + rel
+	if info.IsDir() {
+		result += sep
+	}
+
+	return result
 }


### PR DESCRIPTION
Before this pull request, `hawkeye` depends on `go-gitignore` library to recognize gitignore file.
But go-gitignore does not support any regexp in gitignore file.

So I decide to use `git2go` to support regexp in gitignore file.